### PR TITLE
Fixed Private Gist Creation

### DIFF
--- a/gist.sh
+++ b/gist.sh
@@ -183,9 +183,9 @@ gist_post ()
   fi
 
   if [ "$_PRIVATE" = "1" ]; then
-    PRIVATE="--data-urlencode private=on"
+    PRIVATE="--data-urlencode public=false"
   else
-    PRIVATE=""
+    PRIVATE="--data-urlencode public=true"
   fi
 
   if [ "$_ANON" != "1" ]; then


### PR DESCRIPTION
I noticed that the -p option was still giving me a public address. The latest API uses public={true|false} now and not private={on|off} so I just changed that.
