### PR TITLE
Updating gist_get() function.

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -82,3 +82,5 @@ h2. Contributors
 1. http://github.com/gmarik
 
 2. http://github.com/rocketraman
+
+3. http://github.com/markcaudill

--- a/gist.sh
+++ b/gist.sh
@@ -81,7 +81,7 @@ help ()
 
 gist_get ()
 {
-  URL="https://gist.github.com/$1.txt"
+  URL="https://raw.github.com/gist/$1"
   log "* reading Gist from $URL"
 
   CMD="curl -s $URL"


### PR DESCRIPTION
Updated gist_get() to use https://raw.github.com/gist/$1 instead of https://raw.github.com/gist/$1 .
